### PR TITLE
feat: Added allocatable property to nodes key

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters-settings:
   dupl:
-    threshold: 100
+    threshold: 110
   funlen:
     lines: 100
     statements: 50

--- a/cmd/cyclonexdx.go
+++ b/cmd/cyclonexdx.go
@@ -169,6 +169,22 @@ func transformToCycloneDXBOM(kbom *model.KBOM) *cyclonedx.BOM { //nolint:funlen
 					Name:  KSOCPrefix + "k8s:node:capacity:ephemeralStorage",
 					Value: n.Capacity.EphemeralStorage,
 				},
+				{
+					Name:  KSOCPrefix + "k8s:node:allocatable:cpu",
+					Value: n.Allocatable.CPU,
+				},
+				{
+					Name:  KSOCPrefix + "k8s:node:allocatable:memory",
+					Value: n.Allocatable.Memory,
+				},
+				{
+					Name:  KSOCPrefix + "k8s:node:allocatable:pods",
+					Value: n.Allocatable.Pods,
+				},
+				{
+					Name:  KSOCPrefix + "k8s:node:allocatable:ephemeralStorage",
+					Value: n.Allocatable.EphemeralStorage,
+				},
 			},
 		})
 	}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -116,9 +116,15 @@ func TestGenerateKBOM(t *testing.T) {
 							Hostname: "ip-10-0-65-00.us-east-1.compute.internal",
 							Capacity: &model.Capacity{
 								CPU:              "2",
-								Memory:           "1973316Ki",
+								Memory:           "1970512Ki",
 								Pods:             "11",
-								EphemeralStorage: "516052280Ki",
+								EphemeralStorage: "524275692Ki",
+							},
+							Allocatable: &model.Capacity{
+								CPU:              "1930m",
+								Memory:           "1483088Ki",
+								Pods:             "11",
+								EphemeralStorage: "482098735124",
 							},
 							Labels: map[string]string{
 								"beta.kubernetes.io/arch":          "amd64",
@@ -145,10 +151,16 @@ func TestGenerateKBOM(t *testing.T) {
 							Type:     "t3.small",
 							Hostname: "ip-10-0-65-01.us-east-1.compute.internal",
 							Capacity: &model.Capacity{
-								CPU:              "4",
-								Memory:           "4000000Ki",
-								Pods:             "45",
-								EphemeralStorage: "516052280Ki",
+								CPU:              "2",
+								Memory:           "1970512Ki",
+								Pods:             "11",
+								EphemeralStorage: "524275692Ki",
+							},
+							Allocatable: &model.Capacity{
+								CPU:              "1930m",
+								Memory:           "1483088Ki",
+								Pods:             "11",
+								EphemeralStorage: "482098735124",
 							},
 							Labels: map[string]string{
 								"beta.kubernetes.io/arch":          "amd64",
@@ -364,9 +376,15 @@ var expectedOutJSON = `{
         "hostname": "ip-10-0-65-00.us-east-1.compute.internal",
         "capacity": {
           "cpu": "2",
-          "memory": "1973316Ki",
+          "memory": "1970512Ki",
           "pods": "11",
-          "ephemeral_storage": "516052280Ki"
+          "ephemeral_storage": "524275692Ki"
+        },
+        "allocatable": {
+          "cpu": "1930m",
+          "memory": "1483088Ki",
+          "pods": "11",
+          "ephemeral_storage": "482098735124"
         },
         "labels": {
           "beta.kubernetes.io/arch": "amd64",
@@ -393,10 +411,16 @@ var expectedOutJSON = `{
         "type": "t3.small",
         "hostname": "ip-10-0-65-01.us-east-1.compute.internal",
         "capacity": {
-          "cpu": "4",
-          "memory": "4000000Ki",
-          "pods": "45",
-          "ephemeral_storage": "516052280Ki"
+          "cpu": "2",
+          "memory": "1970512Ki",
+          "pods": "11",
+          "ephemeral_storage": "524275692Ki"
+        },
+        "allocatable": {
+          "cpu": "1930m",
+          "memory": "1483088Ki",
+          "pods": "11",
+          "ephemeral_storage": "482098735124"
         },
         "labels": {
           "beta.kubernetes.io/arch": "amd64",

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -214,6 +214,9 @@ var expectedSchema = `{
         "capacity": {
           "$ref": "#/$defs/Capacity"
         },
+        "allocatable": {
+          "$ref": "#/$defs/Capacity"
+        },
         "labels": {
           "patternProperties": {
             ".*": {
@@ -265,6 +268,7 @@ var expectedSchema = `{
         "type",
         "hostname",
         "capacity",
+        "allocatable",
         "labels",
         "annotations",
         "machine_id",

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -10,6 +10,7 @@ Instances
 - CloudType
 - Creation Timestamp
 - Capacity
+- Allocatable resources
 - OS Version
 - Kernel Version
 - Architecture

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -21,23 +21,27 @@ Following Taxonomy is used by the `KBOM` tool as extension to: [https://github.c
 
 ## `ksoc:kbom:k8s:node` Namespace Taxonomy
 
-| Property                                       | Description                       |
-| ---------------------------------------------- | --------------------------------- |
-| `ksoc:kbom:k8s:node:osImage`                   | Node's operating system image     |
-| `ksoc:kbom:k8s:node:arch`                      | Node's architecture               |
-| `ksoc:kbom:k8s:node:kernel`                    | Node's kernel version             |
-| `ksoc:kbom:k8s:node:bootId`                    | Node's Boot identifier            |
-| `ksoc:kbom:k8s:node:type`                      | Node's type                       |
-| `ksoc:kbom:k8s:node:operatingSystem`           | Node's operating system           |
-| `ksoc:kbom:k8s:node:machineId`                 | Node's machine identifier         |
-| `ksoc:kbom:k8s:node:hostname`                  | Node's hostname                   |
-| `ksoc:kbom:k8s:node:containerRuntimeVersion`   | Node's container runtime version  |
-| `ksoc:kbom:k8s:node:kubeletVersion`            | Node's kubelet version            |
-| `ksoc:kbom:k8s:node:kubeProxyVersion`          | Node's kube proxy version         |
-| `ksoc:kbom:k8s:node:capacity:cpu`              | Node's CPU capacity               |
-| `ksoc:kbom:k8s:node:capacity:memory`           | Node's Memory capacity            |
-| `ksoc:kbom:k8s:node:capacity:pods`             | Node's Pods capacity              |
-| `ksoc:kbom:k8s:node:capacity:ephemeralStorage` | Node's ephemeral storage capacity |
+| Property                                           | Description                          |
+| -------------------------------------------------- | ------------------------------------ |
+| `ksoc:kbom:k8s:node:osImage`                       | Node's operating system image        |
+| `ksoc:kbom:k8s:node:arch`                          | Node's architecture                  |
+| `ksoc:kbom:k8s:node:kernel`                        | Node's kernel version                |
+| `ksoc:kbom:k8s:node:bootId`                        | Node's Boot identifier               |
+| `ksoc:kbom:k8s:node:type`                          | Node's type                          |
+| `ksoc:kbom:k8s:node:operatingSystem`               | Node's operating system              |
+| `ksoc:kbom:k8s:node:machineId`                     | Node's machine identifier            |
+| `ksoc:kbom:k8s:node:hostname`                      | Node's hostname                      |
+| `ksoc:kbom:k8s:node:containerRuntimeVersion`       | Node's container runtime version     |
+| `ksoc:kbom:k8s:node:kubeletVersion`                | Node's kubelet version               |
+| `ksoc:kbom:k8s:node:kubeProxyVersion`              | Node's kube proxy version            |
+| `ksoc:kbom:k8s:node:capacity:cpu`                  | Node's CPU capacity                  |
+| `ksoc:kbom:k8s:node:capacity:memory`               | Node's Memory capacity               |
+| `ksoc:kbom:k8s:node:capacity:pods`                 | Node's Pods capacity                 |
+| `ksoc:kbom:k8s:node:capacity:ephemeralStorage`     | Node's ephemeral storage capacity    |
+| `ksoc:kbom:k8s:node:allocatable:cpu`               | Node's allocatable CPU               |
+| `ksoc:kbom:k8s:node:allocatable:memory`            | Node's allocatable Memory            |
+| `ksoc:kbom:k8s:node:allocatable:pods`              | Node's allocatable Pods              |
+| `ksoc:kbom:k8s:node:allocatable:ephemeralStorage`  | Node's allocatable ephemeral storage |
 
 ## `ksoc:kbom:pkg` Namespace Taxonomy
 

--- a/internal/kube/kube.go
+++ b/internal/kube/kube.go
@@ -138,6 +138,12 @@ func (k *k8sDB) AllNodes(ctx context.Context, full bool) ([]model.Node, error) {
 				EphemeralStorage: nodes.Items[i].Status.Capacity.StorageEphemeral().String(),
 				Pods:             nodes.Items[i].Status.Capacity.Pods().String(),
 			},
+			Allocatable: &model.Capacity{
+				CPU:              nodes.Items[i].Status.Allocatable.Cpu().String(),
+				Memory:           nodes.Items[i].Status.Allocatable.Memory().String(),
+				EphemeralStorage: nodes.Items[i].Status.Allocatable.StorageEphemeral().String(),
+				Pods:             nodes.Items[i].Status.Allocatable.Pods().String(),
+			},
 			Labels:                  labels,
 			Annotations:             annotations,
 			MachineID:               nodes.Items[i].Status.NodeInfo.MachineID,

--- a/internal/model/kbom.go
+++ b/internal/model/kbom.go
@@ -66,6 +66,7 @@ type Node struct {
 	Type                    string            `json:"type"`
 	Hostname                string            `json:"hostname"`
 	Capacity                *Capacity         `json:"capacity"`
+	Allocatable             *Capacity         `json:"allocatable"`
 	Labels                  map[string]string `json:"labels"`
 	Annotations             map[string]string `json:"annotations"`
 	MachineID               string            `json:"machine_id"`


### PR DESCRIPTION
# Summary
Adds the `allocatable` resources property under the `nodes` key, which gives a more clear idea of the actual resource availability in the target cluster. With this information we can answer things like: what else could I schedule in these nodes or why is this node this saturated if only these tiny workloads are running there (potential attack where someone is running containers that were scheduled out of band).

Discussed [here](https://github.com/ksoclabs/kbom/discussions/81)