### PR TITLE
Donwgrade docker/login-action to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@v0.14.3 # installs syft
 
       - name: Login to GCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           registry: us.gcr.io
           username: _json_key


### PR DESCRIPTION
GoReleaser doesn't work with docker/login-action@v3