### PR TITLE
feat: Add namespace to image properties

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -187,16 +187,18 @@ func TestGenerateKBOM(t *testing.T) {
 				allImages: func(context.Context) ([]model.Image, error) {
 					return []model.Image{
 						{
-							Name:     "nginx",
-							Version:  "1.17.1",
-							FullName: "nginx:1.17.1",
-							Digest:   "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+							Name:      "nginx",
+							Version:   "1.17.1",
+							FullName:  "nginx:1.17.1",
+							Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+							Namespace: "default",
 						},
 						{
-							Name:     "redis",
-							Version:  "7.0.1",
-							FullName: "redis:7.0.1",
-							Digest:   "sha256:0000000000000000000000000000000000000000000000000000000000000002",
+							Name:      "redis",
+							Version:   "7.0.1",
+							FullName:  "redis:7.0.1",
+							Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000002",
+							Namespace: "default",
 						},
 					}, nil
 				},
@@ -449,13 +451,15 @@ var expectedOutJSON = `{
           "full_name": "nginx:1.17.1",
           "name": "nginx",
           "version": "1.17.1",
-          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+          "namespace": "default"
         },
         {
           "full_name": "redis:7.0.1",
           "name": "redis",
           "version": "7.0.1",
-          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000002",
+          "namespace": "default"
         }
       ],
       "resources": {

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -134,6 +134,9 @@ var expectedSchema = `{
         },
         "digest": {
           "type": "string"
+        },
+        "namespace": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -142,7 +145,8 @@ var expectedSchema = `{
         "full_name",
         "name",
         "version",
-        "digest"
+        "digest",
+        "namespace"
       ]
     },
     "KBOM": {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,6 +23,7 @@ Images
 - FullName
 - Version
 - Digest
+- Namespace
 
 KubeObjects
 - Kind

--- a/internal/model/kbom.go
+++ b/internal/model/kbom.go
@@ -81,10 +81,11 @@ type Node struct {
 }
 
 type Image struct {
-	FullName string `json:"full_name"`
-	Name     string `json:"name"`
-	Version  string `json:"version"`
-	Digest   string `json:"digest"`
+	FullName  string `json:"full_name"`
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	Digest    string `json:"digest"`
+	Namespace string `json:"namespace"`
 }
 
 func (i *Image) PkgID() string {


### PR DESCRIPTION
As of now, the namespace is not part of the Images. This change will help to identify which image belongs to which namespace in a given cluster.

The sample images JSON:
```
  "components": {
    "images": [
     {
          "full_name": "registry.k8s.io/kube-apiserver:v1.27.3",
          "name": "registry.k8s.io/kube-apiserver",
          "version": "v1.27.3",
          "digest": "sha256:024134bb4e61a4975c5c15db76a7e3571eea74eff90c12a730781bf9c9daedd0",
          "namespace":"kube-system"
      },

```