### PR TITLE
Ignore unsupported windows/arm build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: arm
     ldflags:
       - -X "{{.Env.CFG_PACKAGE_NAME}}.AppName=kbom"
       - -X "{{.Env.CFG_PACKAGE_NAME}}.AppVersion={{.Env.VERSION}}"


### PR DESCRIPTION
## Summary

- Add `windows/arm` to the goreleaser `ignore` list — Go no longer supports the 32-bit `windows/arm` GOOS/GOARCH pair (only `windows/arm64`).
- Fixes the release build failure: `failed to build for windows_arm_7: exit status 2: go: unsupported GOOS/GOARCH pair windows/arm`.