### PR TITLE
Point Homebrew tap to renamed homebrew-tap repo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,7 +75,7 @@ signs:
 brews:
   - repository:
       owner: rad-security
-      name: homebrew
+      name: homebrew-tap
     homepage: "https://github.com/rad-security/kbom"
     description: "The Kubernetes Bill of Materials (KBOM) standard provides insight into container orchestration tools widely used across the industry."
     license: "Apache 2"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you prefer to download the binary, you can do so from the [releases page](htt
 ### Installation
 
 ```sh
-brew install rad-security/homebrew/kbom
+brew install rad-security/tap/kbom
 ```
 
 or


### PR DESCRIPTION
## Summary

- The shared tap repo was renamed from \`rad-security/homebrew\` to \`rad-security/homebrew-tap\` so it matches Homebrew's naming convention (\`brew tap <user>/<x>\` clones \`<user>/homebrew-<x>\`).
- Without this change the next \`kbom\` release would still attempt to push the formula to the old repo name, and \`brew install rad-security/homebrew/kbom\` would not work for new users (only the GitHub redirect from the old \`homebrew-kbom\` name keeps the existing install path alive).
- This PR updates \`.goreleaser.yml\` to publish to \`homebrew-tap\` and updates the README install command to \`brew install rad-security/tap/kbom\`.

## Test plan

- [ ] Cut a new \`kbom\` tag and confirm goreleaser pushes the formula to \`rad-security/homebrew-tap\` (no auth/repo errors in the \`homebrew tap formula\` step).
- [ ] On a clean machine: \`brew install rad-security/tap/kbom\` succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)